### PR TITLE
[1.21] Fix gleaming ore Silk Touch predicate being incorrect

### DIFF
--- a/src/main/resources/data/things/loot_table/blocks/deepslate_gleaming_ore.json
+++ b/src/main/resources/data/things/loot_table/blocks/deepslate_gleaming_ore.json
@@ -13,14 +13,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantment": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/things/loot_table/blocks/gleaming_ore.json
+++ b/src/main/resources/data/things/loot_table/blocks/gleaming_ore.json
@@ -13,14 +13,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantment": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],


### PR DESCRIPTION
Fixes issues with a inability to break the ore to get the gleaming powder.